### PR TITLE
Add layer.compose() method

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libpng"]
 	path = libpng
 	url = https://github.com/glennrp/libpng.git
+[submodule "lunasvg"]
+	path = lunasvg
+	url = https://github.com/sammycage/lunasvg.git

--- a/SConstruct
+++ b/SConstruct
@@ -233,7 +233,7 @@ elif env['platform'] == 'osx':
     ])
 
     if env['target'] == 'debug':
-        env.Append(CCFLAGS=['-Og', 'g'])
+        env.Append(CCFLAGS=['-Og', '-g'])
     elif env['target'] == 'release':
         env.Append(CCFLAGS=['-O3'])
 
@@ -287,20 +287,49 @@ elif env['platform'] == 'windows':
 
 env.Append(CPPPATH=['.', 'zlib/'])
 env.Append(CPPPATH=['src/'])
-sources = [
+env.Append(CPPPATH=['lunasvg/include/'])
+env.Append(CPPPATH=['lunasvg/source/'])
+env.Append(CPPPATH=['lunasvg/plutovg/include/'])
+env.Append(CPPPATH=['lunasvg/plutovg/source/'])
+
+# Common library sources (without main programs)
+lib_sources = [
     Glob('libpng/*.c',exclude=['libpng/pngtest.c']),
-    Glob('libkra_cl/*.cpp'), 
     Glob('libkra/*.cpp'),
     'tinyxml2/tinyxml2.cpp',
     Glob('zlib/*.c'),
     Glob('zlib/contrib/minizip/unzip.c'),
-    Glob('zlib/contrib/minizip/ioapi.c')
+    Glob('zlib/contrib/minizip/ioapi.c'),
+    # lunasvg sources
+    Glob('lunasvg/source/*.cpp'),
+    # plutovg sources
+    'lunasvg/plutovg/source/plutovg-blend.c',
+    'lunasvg/plutovg/source/plutovg-canvas.c',
+    'lunasvg/plutovg/source/plutovg-font.c',
+    'lunasvg/plutovg/source/plutovg-matrix.c',
+    'lunasvg/plutovg/source/plutovg-paint.c',
+    'lunasvg/plutovg/source/plutovg-path.c',
+    'lunasvg/plutovg/source/plutovg-rasterize.c',
+    'lunasvg/plutovg/source/plutovg-surface.c',
+    'lunasvg/plutovg/source/plutovg-ft-math.c',
+    'lunasvg/plutovg/source/plutovg-ft-raster.c',
+    'lunasvg/plutovg/source/plutovg-ft-stroker.c'
 ]
 
+# libkra_cl sources
+libkra_cl_sources = lib_sources + Glob('libkra_cl/*.cpp')
+
+# kra-filtered-export sources
+filtered_export_sources = lib_sources + ['examples/kra-filtered-export.cpp']
+
 ###############
-#BUILD LIB#####
+#BUILD#########
 ###############
 
-library = env.Program(target=env['target_path'] + env['target_name'], source=sources)
+# Build libkra_cl
+library = env.Program(target=env['target_path'] + env['target_name'], source=libkra_cl_sources)
 
-Default(library)
+# Build kra-filtered-export
+filtered_export = env.Program(target=env['target_path'] + 'kra-filtered-export', source=filtered_export_sources)
+
+Default(library, filtered_export)

--- a/examples/kra-filtered-export.cpp
+++ b/examples/kra-filtered-export.cpp
@@ -22,23 +22,40 @@ enum FilterAction
 	DENY
 };
 
+enum MatchValue
+{
+        MATCH_LAYER_NAME,
+        MATCH_LAYER_TYPE
+};
+
 struct FilterRule
 {
 	std::regex pattern;
+        MatchValue match_value;
 	FilterAction action;
 };
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Check if a layer should be included based on filter rules
 // ---------------------------------------------------------------------------------------------------------------------
-bool should_include_layer(const std::string &layer_name,
+bool should_include_layer(std::unique_ptr<kra::Layer> const& layer,
 						  const std::vector<FilterRule> &rules,
 						  FilterAction default_action)
 {
 	// Check each rule in order
 	for (const auto &rule : rules)
 	{
-		if (std::regex_search(layer_name, rule.pattern))
+                std::string value;
+                switch (rule.match_value)
+                {
+                        case MATCH_LAYER_NAME:
+                                value = layer->name;
+                                break;
+                        case MATCH_LAYER_TYPE:
+                                value = layer_type_to_string(layer->type);
+                                break;
+                }
+		if (std::regex_search(value, rule.pattern))
 		{
 			return rule.action == ACCEPT;
 		}
@@ -143,7 +160,7 @@ bool compose_and_export(const std::unique_ptr<kra::Document> &document,
 		const auto &layer = *it;
 
 		// Check if layer passes filter
-		if (!should_include_layer(layer->name, filter_rules, default_action))
+		if (!should_include_layer(layer, filter_rules, default_action))
 		{
 			std::cout << "  Skipping layer: " << layer->name << " (filtered out)" << std::endl;
 			continue;
@@ -156,6 +173,74 @@ bool compose_and_export(const std::unique_ptr<kra::Document> &document,
 	// Save the composed result
 	std::cout << "Writing composed image to: " << output_filename << std::endl;
 	return write_png(output_filename.c_str(), width, height, composed_buffer.data());
+}
+
+static bool try_simple_option(int i, const char **argv, const char *arg_name)
+{
+        const char *arg = argv[i];
+        return arg[0] == '-' && arg[1] == '-' && strcmp(arg + 2, arg_name) == 0;
+}
+
+static bool try_option(int *i_inout, const char **argv, const char *arg_name, std::string *out)
+{
+        const char *arg = argv[*i_inout];
+        int len = strlen(arg_name);
+        if (arg[0] == '-' && arg[1] == '-' && strcmp(arg + 2, arg_name) == 0 && argv[*i_inout + 1] != NULL)
+        {
+                *out = argv[*i_inout + 1];
+                *i_inout += 1;
+                return true;
+        }
+        if (arg[0] == '-' && arg[1] == '-' && strncmp(arg + 2, arg_name, len) == 0 && arg[2 + len] == '=')
+        {
+                *out = arg + 2 + len + 1;
+                return true;
+        }
+        return false;
+}
+
+
+static bool try_regex_rule_option(int *i_inout, const char **argv, const char *arg_name, MatchValue match_value, FilterAction action, std::vector<FilterRule> *rules)
+{
+        std::string value;
+        if (try_option(i_inout, argv, arg_name, &value)) {
+                try
+                {
+                        rules->push_back(FilterRule{std::regex(value), match_value, action});
+                        return true;
+                }
+                catch (const std::regex_error &e)
+                {
+                        std::cerr << "Invalid regex pattern: " << value << std::endl;
+                        exit(1);
+                }
+        }
+        return false;
+}
+
+
+
+void dump_layer_recursive(std::unique_ptr<kra::Layer> const& layer, int indent)
+{
+      for (int i =0 ; i < indent; i++)
+          std::cout << "  ";
+      std::cout << layer->name << " [" << layer_type_to_string(layer->type) << "]" << std::endl;
+      if (layer->type == kra::GROUP_LAYER)
+      {
+          for (auto it = layer->children.rbegin(); it != layer->children.rend(); ++it)
+          {
+              const auto &sublayer = *it;
+              dump_layer_recursive(sublayer, indent + 1);
+          }
+      }
+}
+
+static void dump_layer_tree(std::unique_ptr<kra::Document>& document)
+{
+      for (auto it = document->layers.rbegin(); it != document->layers.rend(); ++it) {
+          const auto &layer = *it;
+          dump_layer_recursive(layer, 0);
+      }
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -171,64 +256,102 @@ int main(int argc, const char *argv[])
 		std::cerr << "Options:" << std::endl;
 		std::cerr << "  --accept=REGEX      Accept layers matching regex pattern" << std::endl;
 		std::cerr << "  --deny=REGEX        Deny layers matching regex pattern" << std::endl;
+		std::cerr << "  --accept-layer-type=REGEX      Accept layers with type matching regex pattern" << std::endl;
+		std::cerr << "  --deny-layer-type=REGEX        Deny layers with type matching regex pattern" << std::endl;
 		std::cerr << "  --default-deny      Change default action to DENY (default is ACCEPT)" << std::endl;
+		std::cerr << "  --default-accept    Change default action to ACCEPT (default)" << std::endl;
+		std::cerr << "  --out=PNGFILENAME   Render file with current filters" << std::endl;
 		std::cerr << std::endl;
 		std::cerr << "Filter rules are evaluated in order. First match wins." << std::endl;
 		return 1;
 	}
 
 	std::string input_file;
-	std::string output_file = "output.png";
 	std::vector<FilterRule> filter_rules;
 	FilterAction default_action = ACCEPT;
+	std::unique_ptr<kra::Document> document;
+        int images_written = 0;
 
 	// Parse command-line arguments
 	for (int i = 1; i < argc; ++i)
 	{
-		std::string arg = argv[i];
-
-		if (arg.substr(0, 9) == "--accept=")
+		std::string arg;
+                if (try_regex_rule_option(&i, argv, "accept", MATCH_LAYER_NAME, ACCEPT, &filter_rules))
 		{
-			std::string pattern = arg.substr(9);
-			try
-			{
-				filter_rules.push_back({std::regex(pattern), ACCEPT});
-			}
-			catch (const std::regex_error &e)
-			{
-				std::cerr << "Invalid regex pattern: " << pattern << std::endl;
-				return 1;
-			}
 		}
-		else if (arg.substr(0, 7) == "--deny=")
+                else if (try_regex_rule_option(&i, argv, "deny", MATCH_LAYER_NAME, DENY, &filter_rules))
+                {
+                }
+                else if (try_regex_rule_option(&i, argv, "accept-layer-type", MATCH_LAYER_TYPE, ACCEPT, &filter_rules))
 		{
-			std::string pattern = arg.substr(7);
-			try
-			{
-				filter_rules.push_back({std::regex(pattern), DENY});
-			}
-			catch (const std::regex_error &e)
-			{
-				std::cerr << "Invalid regex pattern: " << pattern << std::endl;
-				return 1;
-			}
 		}
-		else if (arg == "--default-deny")
+                else if (try_regex_rule_option(&i, argv, "deny-layer-type", MATCH_LAYER_TYPE, DENY, &filter_rules))
+                {
+                }
+		else if (try_simple_option(i, argv, "default-deny"))
 		{
 			default_action = DENY;
 		}
-		else if (input_file.empty())
+		else if (try_simple_option(i, argv, "default-accept"))
 		{
-			input_file = arg;
+			default_action = ACCEPT;
 		}
-		else if (output_file == "output.png")
+		else if (try_simple_option(i, argv, "clear-rules"))
 		{
-			output_file = arg;
+                        filter_rules.clear();
+		}
+		else if (try_simple_option(i, argv, "print-layer-tree"))
+		{
+                        dump_layer_tree(document);
+		}
+		else if (try_option(&i, argv, "out", &arg))
+		{
+                        // Compose and export
+                        if (!compose_and_export(document, arg, filter_rules, default_action))
+                        {
+                                std::cerr << "Failed to compose and export document" << std::endl;
+                                return 1;
+                        }
+                        images_written += 1;
+                }
+                else if (argv[i][0] == '-')
+                {
+                        std::cerr << "unknown option: " << arg << std::endl;
+                        return 1;
+                }
+		else if (!document)
+		{
+			input_file = argv[i];
+
+	                // Convert to wstring for document load
+	                std::wstring input_wstr(input_file.begin(), input_file.end());
+
+                        // Load the document
+                        document = std::make_unique<kra::Document>();
+                        int result = document->load(input_wstr);
+                        if (result != 0)
+                        {
+                                std::cerr << "Failed to load document: " << input_file << std::endl;
+                                return result;
+                        }
+
+                        // Only handle RGBA documents for now
+                        if (document->color_space != kra::ColorSpace::RGBA)
+                        {
+                                std::cerr << "ERROR: Only RGBA color space is currently supported" << std::endl;
+                                std::cerr << "Document color space: " << kra::get_color_space_name(document->color_space) << std::endl;
+                                return 1;
+                        }
 		}
 		else
 		{
-			std::cerr << "Unknown argument: " << arg << std::endl;
-			return 1;
+                        // Compose and export
+                        if (!compose_and_export(document, argv[i], filter_rules, default_action))
+                        {
+                                std::cerr << "Failed to compose and export document" << std::endl;
+                                return 1;
+                        }
+                        images_written += 1;
 		}
 	}
 
@@ -238,33 +361,10 @@ int main(int argc, const char *argv[])
 		return 1;
 	}
 
-	// Convert to wstring for document load
-	std::wstring input_wstr(input_file.begin(), input_file.end());
+        if (images_written == 0)
+        {
+                std::cerr << "warning: no files written" << std::endl;
+        }
 
-	// Load the document
-	std::unique_ptr<kra::Document> document = std::make_unique<kra::Document>();
-	int result = document->load(input_wstr);
-	if (result != 0)
-	{
-		std::cerr << "Failed to load document: " << input_file << std::endl;
-		return result;
-	}
-
-	// Only handle RGBA documents for now
-	if (document->color_space != kra::ColorSpace::RGBA)
-	{
-		std::cerr << "ERROR: Only RGBA color space is currently supported" << std::endl;
-		std::cerr << "Document color space: " << kra::get_color_space_name(document->color_space) << std::endl;
-		return 1;
-	}
-
-	// Compose and export
-	if (!compose_and_export(document, output_file, filter_rules, default_action))
-	{
-		std::cerr << "Failed to compose and export document" << std::endl;
-		return 1;
-	}
-
-	std::cout << "Successfully exported to: " << output_file << std::endl;
 	return 0;
 }

--- a/examples/kra-filtered-export.cpp
+++ b/examples/kra-filtered-export.cpp
@@ -1,0 +1,270 @@
+// ############################################################################ #
+// Example program: kra-filtered-export
+// Demonstrates composing layers from a KRA file into a single PNG output
+// ############################################################################ #
+
+#include "../libkra/kra_utility.h"
+#include "../libkra/kra_document.h"
+#include "../libkra/kra_layer.h"
+#include "../libpng/png.h"
+
+#include <iostream>
+#include <vector>
+#include <regex>
+#include <string>
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Filter action types
+// ---------------------------------------------------------------------------------------------------------------------
+enum FilterAction
+{
+	ACCEPT,
+	DENY
+};
+
+struct FilterRule
+{
+	std::regex pattern;
+	FilterAction action;
+};
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Check if a layer should be included based on filter rules
+// ---------------------------------------------------------------------------------------------------------------------
+bool should_include_layer(const std::string &layer_name,
+						  const std::vector<FilterRule> &rules,
+						  FilterAction default_action)
+{
+	// Check each rule in order
+	for (const auto &rule : rules)
+	{
+		if (std::regex_search(layer_name, rule.pattern))
+		{
+			return rule.action == ACCEPT;
+		}
+	}
+
+	// No match, use default
+	return default_action == ACCEPT;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Export RGBA data to a PNG file
+// ---------------------------------------------------------------------------------------------------------------------
+bool write_png(const char *filename, unsigned int width, unsigned int height, const uint8_t *rgba_data)
+{
+	bool success = true;
+	FILE *fp = NULL;
+	png_structp png_ptr = NULL;
+	png_infop info_ptr = NULL;
+	png_bytep row = NULL;
+
+	fp = fopen(filename, "wb");
+	if (fp == NULL)
+	{
+		std::cerr << "Could not open file " << filename << " for writing" << std::endl;
+		return false;
+	}
+
+	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+	if (png_ptr == NULL)
+	{
+		std::cerr << "Could not allocate write struct" << std::endl;
+		fclose(fp);
+		return false;
+	}
+
+	info_ptr = png_create_info_struct(png_ptr);
+	if (info_ptr == NULL)
+	{
+		std::cerr << "Could not allocate info struct" << std::endl;
+		png_destroy_write_struct(&png_ptr, NULL);
+		fclose(fp);
+		return false;
+	}
+
+	if (setjmp(png_jmpbuf(png_ptr)))
+	{
+		std::cerr << "Error during png creation" << std::endl;
+		png_destroy_write_struct(&png_ptr, &info_ptr);
+		fclose(fp);
+		return false;
+	}
+
+	png_init_io(png_ptr, fp);
+
+	png_set_IHDR(png_ptr, info_ptr, width, height, 8, PNG_COLOR_TYPE_RGBA,
+				 PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
+
+	png_write_info(png_ptr, info_ptr);
+
+	row = (png_bytep)malloc(4 * width * sizeof(png_byte));
+
+	for (unsigned int y = 0; y < height; y++)
+	{
+		memcpy(row, &rgba_data[4 * width * y], 4 * width * sizeof(png_byte));
+		png_write_row(png_ptr, row);
+	}
+
+	png_write_end(png_ptr, NULL);
+
+	if (fp != NULL)
+		fclose(fp);
+	if (info_ptr != NULL)
+		png_free_data(png_ptr, info_ptr, PNG_FREE_ALL, -1);
+	if (png_ptr != NULL)
+		png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
+	if (row != NULL)
+		std::free(row);
+
+	return success;
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Compose all layers and save to PNG
+// ---------------------------------------------------------------------------------------------------------------------
+bool compose_and_export(const std::unique_ptr<kra::Document> &document,
+						const std::string &output_filename,
+						const std::vector<FilterRule> &filter_rules,
+						FilterAction default_action)
+{
+	unsigned int width = document->width;
+	unsigned int height = document->height;
+
+	std::cout << "Composing document: " << width << "x" << height << std::endl;
+
+	// Allocate RGBA buffer initialized to transparent
+	std::vector<uint8_t> composed_buffer(width * height * 4, 0);
+
+	// Compose each layer onto the buffer (from bottom to top)
+	// Note: layers are stored in reverse order (top layer first), so iterate backwards
+	for (auto it = document->layers.rbegin(); it != document->layers.rend(); ++it)
+	{
+		const auto &layer = *it;
+
+		// Check if layer passes filter
+		if (!should_include_layer(layer->name, filter_rules, default_action))
+		{
+			std::cout << "  Skipping layer: " << layer->name << " (filtered out)" << std::endl;
+			continue;
+		}
+
+		std::cout << "  Composing layer: " << layer->name << " (type " << layer->type << ")" << std::endl;
+		layer->compose(width, height, document->x_res, composed_buffer.data());
+	}
+
+	// Save the composed result
+	std::cout << "Writing composed image to: " << output_filename << std::endl;
+	return write_png(output_filename.c_str(), width, height, composed_buffer.data());
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------------------------------------------------
+int main(int argc, const char *argv[])
+{
+	if (argc < 2)
+	{
+		std::cerr << "Usage: " << argv[0] << " <input.kra> [output.png] [options]" << std::endl;
+		std::cerr << "  Composes layers from a KRA file into a single PNG" << std::endl;
+		std::cerr << std::endl;
+		std::cerr << "Options:" << std::endl;
+		std::cerr << "  --accept=REGEX      Accept layers matching regex pattern" << std::endl;
+		std::cerr << "  --deny=REGEX        Deny layers matching regex pattern" << std::endl;
+		std::cerr << "  --default-deny      Change default action to DENY (default is ACCEPT)" << std::endl;
+		std::cerr << std::endl;
+		std::cerr << "Filter rules are evaluated in order. First match wins." << std::endl;
+		return 1;
+	}
+
+	std::string input_file;
+	std::string output_file = "output.png";
+	std::vector<FilterRule> filter_rules;
+	FilterAction default_action = ACCEPT;
+
+	// Parse command-line arguments
+	for (int i = 1; i < argc; ++i)
+	{
+		std::string arg = argv[i];
+
+		if (arg.substr(0, 9) == "--accept=")
+		{
+			std::string pattern = arg.substr(9);
+			try
+			{
+				filter_rules.push_back({std::regex(pattern), ACCEPT});
+			}
+			catch (const std::regex_error &e)
+			{
+				std::cerr << "Invalid regex pattern: " << pattern << std::endl;
+				return 1;
+			}
+		}
+		else if (arg.substr(0, 7) == "--deny=")
+		{
+			std::string pattern = arg.substr(7);
+			try
+			{
+				filter_rules.push_back({std::regex(pattern), DENY});
+			}
+			catch (const std::regex_error &e)
+			{
+				std::cerr << "Invalid regex pattern: " << pattern << std::endl;
+				return 1;
+			}
+		}
+		else if (arg == "--default-deny")
+		{
+			default_action = DENY;
+		}
+		else if (input_file.empty())
+		{
+			input_file = arg;
+		}
+		else if (output_file == "output.png")
+		{
+			output_file = arg;
+		}
+		else
+		{
+			std::cerr << "Unknown argument: " << arg << std::endl;
+			return 1;
+		}
+	}
+
+	if (input_file.empty())
+	{
+		std::cerr << "Error: No input file specified" << std::endl;
+		return 1;
+	}
+
+	// Convert to wstring for document load
+	std::wstring input_wstr(input_file.begin(), input_file.end());
+
+	// Load the document
+	std::unique_ptr<kra::Document> document = std::make_unique<kra::Document>();
+	int result = document->load(input_wstr);
+	if (result != 0)
+	{
+		std::cerr << "Failed to load document: " << input_file << std::endl;
+		return result;
+	}
+
+	// Only handle RGBA documents for now
+	if (document->color_space != kra::ColorSpace::RGBA)
+	{
+		std::cerr << "ERROR: Only RGBA color space is currently supported" << std::endl;
+		std::cerr << "Document color space: " << kra::get_color_space_name(document->color_space) << std::endl;
+		return 1;
+	}
+
+	// Compose and export
+	if (!compose_and_export(document, output_file, filter_rules, default_action))
+	{
+		std::cerr << "Failed to compose and export document" << std::endl;
+		return 1;
+	}
+
+	std::cout << "Successfully exported to: " << output_file << std::endl;
+	return 0;
+}

--- a/libkra/kra_document.cpp
+++ b/libkra/kra_document.cpp
@@ -52,6 +52,8 @@ namespace kra
         const tinyxml2::XMLElement *xml_element = xml_document.FirstChildElement("DOC")->FirstChildElement("IMAGE");
         width = xml_element->UnsignedAttribute("width", 0);
         height = xml_element->UnsignedAttribute("height", 0);
+        x_res = xml_element->UnsignedAttribute("x-res", 72);
+        y_res = xml_element->UnsignedAttribute("y-res", 72);
         name = xml_element->Attribute("name");
         std::string color_space_name = xml_element->Attribute("colorspacename");
         /* Each separate layer also has its own color space in KRA, so this color_space isn't really important */
@@ -166,18 +168,10 @@ namespace kra
             /* Check the type of the layer and proceed from there... */
             std::string node_type = layer_node->Attribute("nodetype");
             std::unique_ptr<Layer> layer = std::make_unique<Layer>();
-            /* If it is not a paintlayer nor a grouplayer then we don't support it! */
-            if (node_type == "paintlayer" || node_type == "grouplayer")
-            {
-                if (node_type == "paintlayer")
-                {
-                    layer->type = PAINT_LAYER;
-                }
-                else
-                {
-                    layer->type = GROUP_LAYER;
-                }
 
+            /* Try to determine the layer type from the node type string */
+            if (layer_type_from_string(node_type, &layer->type))
+            {
                 layer->import_attributes(name, p_file, layer_node);
 
                 if (verbosity_level >= VERBOSE)

--- a/libkra/kra_document.h
+++ b/libkra/kra_document.h
@@ -35,6 +35,8 @@ namespace kra
 
 		unsigned int width;
 		unsigned int height;
+		unsigned int x_res = 72;  // DPI (dots per inch) - default 72
+		unsigned int y_res = 72;
 
 		ColorSpace color_space;
 

--- a/libkra/kra_layer.cpp
+++ b/libkra/kra_layer.cpp
@@ -6,6 +6,8 @@
 
 #include "kra_layer.h"
 
+#include <lunasvg.h>
+
 namespace kra
 {
     // ---------------------------------------------------------------------------------------------------------------------
@@ -31,6 +33,9 @@ namespace kra
             break;
         case GROUP_LAYER:
             _import_group_attributes(p_name, p_file, p_xml_element);
+            break;
+        case VECTOR_LAYER:
+            _import_vector_attributes(p_name, p_file, p_xml_element);
             break;
         }
     }
@@ -72,6 +77,10 @@ namespace kra
                 exported_layer->child_uuids.push_back(child->uuid);
             }
             break;
+        case VECTOR_LAYER:
+            // Vector layer data is available in svg_content
+            // Applications can access the raw SVG data for rendering
+            break;
         }
 
         return exported_layer;
@@ -100,6 +109,9 @@ namespace kra
         case GROUP_LAYER:
             _print_group_layer_attributes();
             break;
+        case VECTOR_LAYER:
+            _print_vector_layer_attributes();
+            break;
         }
     }
 
@@ -126,6 +138,30 @@ namespace kra
             /* Start extracting the tile data. */
             layer_data = std::make_unique<LayerData>();
             layer_data->import_attributes(layer_content);
+
+            /* Also try to load the default pixel if it exists */
+            layer_data->has_default_pixel = false;
+            const std::string &default_pixel_path = p_name + "/layers/" + filename + ".defaultpixel";
+            std::vector<unsigned char> default_pixel_content;
+            int default_pixel_error = unzLocateFile(p_file, default_pixel_path.c_str(), 1);
+            default_pixel_error += extract_current_file_to_vector(p_file, default_pixel_content);
+            if (default_pixel_error == UNZ_OK && default_pixel_content.size() >= 4)
+            {
+                layer_data->default_pixel[0] = default_pixel_content[0];
+                layer_data->default_pixel[1] = default_pixel_content[1];
+                layer_data->default_pixel[2] = default_pixel_content[2];
+                layer_data->default_pixel[3] = default_pixel_content[3];
+                layer_data->has_default_pixel = true;
+                if (verbosity_level >= VERBOSE)
+                {
+                    fprintf(stdout, "   >> Loaded default pixel for layer '%s': R=%d G=%d B=%d A=%d\n",
+                            name.c_str(),
+                            layer_data->default_pixel[0],
+                            layer_data->default_pixel[1],
+                            layer_data->default_pixel[2],
+                            layer_data->default_pixel[3]);
+                }
+            }
         }
         else
         {
@@ -147,17 +183,10 @@ namespace kra
             /* Check the type of the layer and proceed from there... */
             std::string node_type = layer_node->Attribute("nodetype");
             std::unique_ptr<Layer> layer = std::make_unique<Layer>();
-            if (node_type == "paintlayer" || node_type == "grouplayer")
-            {
-                if (node_type == "paintlayer")
-                {
-                    layer->type = PAINT_LAYER;
-                }
-                else
-                {
-                    layer->type = GROUP_LAYER;
-                }
 
+            /* Try to determine the layer type from the node type string */
+            if (layer_type_from_string(node_type, &layer->type))
+            {
                 layer->import_attributes(p_name, p_file, layer_node);
 
                 if (verbosity_level >= VERBOSE)
@@ -201,6 +230,271 @@ namespace kra
         for (const auto &layer : children)
         {
             fprintf(stdout, "      - '%s' (%s)\n", layer->name.c_str(), layer->uuid.c_str());
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------------
+    // Extract attributes specific to this layer's type (= VECTOR_LAYER) and load the SVG content
+    // ---------------------------------------------------------------------------------------------------------------------
+    void Layer::_import_vector_attributes(const std::string &p_name, unzFile &p_file, const tinyxml2::XMLElement *p_xml_element)
+    {
+        /* Vector layers are stored in a directory named <filename>.shapelayer/content.svg */
+        const std::string &svg_path = p_name + "/layers/" + filename + ".shapelayer/content.svg";
+        const char *c_path = svg_path.c_str();
+        int errorCode = unzLocateFile(p_file, c_path, 1);
+        errorCode += extract_current_file_to_vector(p_file, svg_content);
+        if (errorCode != UNZ_OK)
+        {
+            fprintf(stdout, "ERROR: Vector layer SVG content with path '%s' could not be found in KRA archive.\n", svg_path.c_str());
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------------
+    // Print additional attributes specific to this layer's type (= VECTOR_LAYER) to the output console
+    // ---------------------------------------------------------------------------------------------------------------------
+    void Layer::_print_vector_layer_attributes() const
+    {
+        fprintf(stdout, "   -- Additional attributes specific to this layer's type (= VECTOR_LAYER):\n");
+        fprintf(stdout, "   >> svg_content size = %zu bytes\n", svg_content.size());
+        if (!svg_content.empty())
+        {
+            fprintf(stdout, "   >> SVG data loaded successfully\n");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------------
+    // Compose this layer on top of the existing RGBA buffer
+    // ---------------------------------------------------------------------------------------------------------------------
+    void Layer::compose(unsigned int document_width, unsigned int document_height, float document_dpi, uint8_t *rgba_inout) const
+    {
+        if (!visible)
+        {
+            return; // Skip invisible layers
+        }
+
+        switch (type)
+        {
+        case PAINT_LAYER:
+        {
+            if (!layer_data)
+            {
+                break;
+            }
+
+            // Get the layer's pixel data
+            std::vector<uint8_t> layer_pixels = layer_data->get_composed_data(color_space);
+
+            // If no tile data but default pixel exists, fill entire document with default pixel
+            if (layer_pixels.empty() && layer_data->has_default_pixel)
+            {
+                // Fill entire document with default pixel
+                for (unsigned int dy = 0; dy < document_height; dy++)
+                {
+                    for (unsigned int dx = 0; dx < document_width; dx++)
+                    {
+                        size_t dst_idx = (dy * document_width + dx) * 4;
+
+                        // Get default pixel color with layer opacity applied
+                        uint8_t src_r = layer_data->default_pixel[0];
+                        uint8_t src_g = layer_data->default_pixel[1];
+                        uint8_t src_b = layer_data->default_pixel[2];
+                        uint8_t src_a = (layer_data->default_pixel[3] * opacity) / 255;
+
+                        // Get destination pixel
+                        uint8_t dst_r = rgba_inout[dst_idx + 0];
+                        uint8_t dst_g = rgba_inout[dst_idx + 1];
+                        uint8_t dst_b = rgba_inout[dst_idx + 2];
+                        uint8_t dst_a = rgba_inout[dst_idx + 3];
+
+                        // Alpha blending
+                        float src_alpha = src_a / 255.0f;
+                        float dst_alpha = dst_a / 255.0f;
+                        float out_alpha = src_alpha + dst_alpha * (1.0f - src_alpha);
+
+                        if (out_alpha > 0.0f)
+                        {
+                            rgba_inout[dst_idx + 0] = (uint8_t)((src_r * src_alpha + dst_r * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                            rgba_inout[dst_idx + 1] = (uint8_t)((src_g * src_alpha + dst_g * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                            rgba_inout[dst_idx + 2] = (uint8_t)((src_b * src_alpha + dst_b * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                            rgba_inout[dst_idx + 3] = (uint8_t)(out_alpha * 255.0f);
+                        }
+                    }
+                }
+                break;
+            }
+
+            if (layer_pixels.empty())
+            {
+                break;
+            }
+
+            int32_t layer_left = layer_data->get_left();
+            int32_t layer_top = layer_data->get_top();
+            int32_t layer_right = layer_data->get_right();
+            int32_t layer_bottom = layer_data->get_bottom();
+            unsigned int layer_width = layer_right - layer_left;
+            unsigned int layer_height = layer_bottom - layer_top;
+
+            // Blend each pixel from the layer onto the document buffer
+            for (unsigned int ly = 0; ly < layer_height; ly++)
+            {
+                for (unsigned int lx = 0; lx < layer_width; lx++)
+                {
+                    int doc_x = x + layer_left + lx;
+                    int doc_y = y + layer_top + ly;
+
+                    // Skip if outside document bounds
+                    if (doc_x < 0 || doc_x >= (int)document_width ||
+                        doc_y < 0 || doc_y >= (int)document_height)
+                    {
+                        continue;
+                    }
+
+                    size_t src_idx = (ly * layer_width + lx) * 4;
+                    size_t dst_idx = (doc_y * document_width + doc_x) * 4;
+
+                    // Get source pixel with layer opacity applied
+                    uint8_t src_r = layer_pixels[src_idx + 0];
+                    uint8_t src_g = layer_pixels[src_idx + 1];
+                    uint8_t src_b = layer_pixels[src_idx + 2];
+                    uint8_t src_a = (layer_pixels[src_idx + 3] * opacity) / 255;
+
+                    // Get destination pixel
+                    uint8_t dst_r = rgba_inout[dst_idx + 0];
+                    uint8_t dst_g = rgba_inout[dst_idx + 1];
+                    uint8_t dst_b = rgba_inout[dst_idx + 2];
+                    uint8_t dst_a = rgba_inout[dst_idx + 3];
+
+                    // Alpha blending: out = src over dst
+                    float src_alpha = src_a / 255.0f;
+                    float dst_alpha = dst_a / 255.0f;
+                    float out_alpha = src_alpha + dst_alpha * (1.0f - src_alpha);
+
+                    if (out_alpha > 0.0f)
+                    {
+                        rgba_inout[dst_idx + 0] = (uint8_t)((src_r * src_alpha + dst_r * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                        rgba_inout[dst_idx + 1] = (uint8_t)((src_g * src_alpha + dst_g * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                        rgba_inout[dst_idx + 2] = (uint8_t)((src_b * src_alpha + dst_b * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                        rgba_inout[dst_idx + 3] = (uint8_t)(out_alpha * 255.0f);
+                    }
+                }
+            }
+            break;
+        }
+        case VECTOR_LAYER:
+        {
+            if (svg_content.empty())
+            {
+                break;
+            }
+
+            // Check for font usage in SVG and warn about missing fonts
+            std::string svg_str((const char*)svg_content.data(), svg_content.size());
+            size_t font_family_pos = svg_str.find("font-family:");
+            if (font_family_pos != std::string::npos)
+            {
+                // Extract font name (rough extraction)
+                size_t start = font_family_pos + 12; // length of "font-family:"
+                while (start < svg_str.size() && (svg_str[start] == ' ' || svg_str[start] == '\t')) start++;
+                size_t end = start;
+                while (end < svg_str.size() && svg_str[end] != ';' && svg_str[end] != '"' && svg_str[end] != '\'' && svg_str[end] != ',') end++;
+
+                if (end > start)
+                {
+                    std::string font_name = svg_str.substr(start, end - start);
+                    // Trim trailing spaces
+                    while (!font_name.empty() && (font_name.back() == ' ' || font_name.back() == '\t'))
+                        font_name.pop_back();
+
+                    if (!font_name.empty() && verbosity_level >= VERBOSE)
+                    {
+                        fprintf(stdout, "   >> Vector layer uses font: %s\n", font_name.c_str());
+                    }
+                }
+            }
+
+            // Parse SVG using lunasvg
+            auto document = lunasvg::Document::loadFromData((const char*)svg_content.data(), svg_content.size());
+            if (!document)
+            {
+                fprintf(stderr, "ERROR: Failed to parse SVG for layer '%s'\n", name.c_str());
+                break;
+            }
+
+            // Calculate scaled dimensions based on DPI
+            // SVG uses 96 DPI as default, so scale based on document DPI
+            float scale = document_dpi / 96.0f;
+            int svg_width = (int)(document->width() * scale);
+            int svg_height = (int)(document->height() * scale);
+
+            // Render to bitmap at the scaled size
+            auto bitmap = document->renderToBitmap(svg_width, svg_height);
+            if (bitmap.isNull())
+            {
+                fprintf(stderr, "ERROR: Failed to rasterize SVG for layer '%s'\n", name.c_str());
+                break;
+            }
+
+            // Convert from ARGB32 Premultiplied to RGBA Plain
+            bitmap.convertToRGBA();
+
+            uint8_t* svg_data = bitmap.data();
+
+            // Blend the rasterized SVG onto the document buffer
+            for (unsigned int sy = 0; sy < svg_height; sy++)
+            {
+                for (unsigned int sx = 0; sx < svg_width; sx++)
+                {
+                    int doc_x = x + sx;
+                    int doc_y = y + sy;
+
+                    // Skip if outside document bounds
+                    if (doc_x < 0 || doc_x >= (int)document_width ||
+                        doc_y < 0 || doc_y >= (int)document_height)
+                    {
+                        continue;
+                    }
+
+                    size_t src_idx = (sy * svg_width + sx) * 4;
+                    size_t dst_idx = (doc_y * document_width + doc_x) * 4;
+
+                    // Get source pixel with layer opacity applied
+                    uint8_t src_r = svg_data[src_idx + 0];
+                    uint8_t src_g = svg_data[src_idx + 1];
+                    uint8_t src_b = svg_data[src_idx + 2];
+                    uint8_t src_a = (svg_data[src_idx + 3] * opacity) / 255;
+
+                    // Get destination pixel
+                    uint8_t dst_r = rgba_inout[dst_idx + 0];
+                    uint8_t dst_g = rgba_inout[dst_idx + 1];
+                    uint8_t dst_b = rgba_inout[dst_idx + 2];
+                    uint8_t dst_a = rgba_inout[dst_idx + 3];
+
+                    // Alpha blending
+                    float src_alpha = src_a / 255.0f;
+                    float dst_alpha = dst_a / 255.0f;
+                    float out_alpha = src_alpha + dst_alpha * (1.0f - src_alpha);
+
+                    if (out_alpha > 0.0f)
+                    {
+                        rgba_inout[dst_idx + 0] = (uint8_t)((src_r * src_alpha + dst_r * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                        rgba_inout[dst_idx + 1] = (uint8_t)((src_g * src_alpha + dst_g * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                        rgba_inout[dst_idx + 2] = (uint8_t)((src_b * src_alpha + dst_b * dst_alpha * (1.0f - src_alpha)) / out_alpha);
+                        rgba_inout[dst_idx + 3] = (uint8_t)(out_alpha * 255.0f);
+                    }
+                }
+            }
+            break;
+        }
+        case GROUP_LAYER:
+        {
+            // Recursively compose all children
+            for (const auto &child : children)
+            {
+                child->compose(document_width, document_height, document_dpi, rgba_inout);
+            }
+            break;
+        }
         }
     }
 };

--- a/libkra/kra_layer.h
+++ b/libkra/kra_layer.h
@@ -24,9 +24,11 @@ namespace kra
     private:
         void _import_paint_attributes(const std::string &p_name, unzFile &p_file, const tinyxml2::XMLElement *p_xml_element);
         void _import_group_attributes(const std::string &p_name, unzFile &p_file, const tinyxml2::XMLElement *p_xml_element);
+        void _import_vector_attributes(const std::string &p_name, unzFile &p_file, const tinyxml2::XMLElement *p_xml_element);
 
         void _print_paint_layer_attributes() const;
         void _print_group_layer_attributes() const;
+        void _print_vector_layer_attributes() const;
 
     public:
         std::string filename;
@@ -49,11 +51,21 @@ namespace kra
         // GROUP_LAYER
         std::vector<std::unique_ptr<Layer>> children;
 
+        // VECTOR_LAYER
+        std::vector<unsigned char> svg_content;
+
         void import_attributes(const std::string &p_name, unzFile &p_file, const tinyxml2::XMLElement *p_xml_element);
 
         std::unique_ptr<ExportedLayer> get_exported_layer() const;
 
         void print_layer_attributes() const;
+
+        // Compose this layer on top of the existing RGBA buffer
+        // For paint layers, blends the layer data onto the buffer
+        // For vector layers, rasterizes the SVG and blends it onto the buffer
+        // rgba_inout: buffer of size document_width * document_height * 4 (RGBA)
+        // document_dpi: document DPI for proper SVG scaling
+        void compose(unsigned int document_width, unsigned int document_height, float document_dpi, uint8_t *rgba_inout) const;
     };
 };
 

--- a/libkra/kra_layer_data.h
+++ b/libkra/kra_layer_data.h
@@ -61,6 +61,10 @@ namespace kra
         // Number of elements in each pixel, is equal to 4 for RGBA.
         unsigned int pixel_size;
 
+        // Default pixel color (for layers with no tile data)
+        uint8_t default_pixel[4];
+        bool has_default_pixel;
+
         void import_attributes(const std::vector<unsigned char> &p_layer_content);
 
         std::vector<uint8_t> get_composed_data(ColorSpace color_space) const;

--- a/libkra/kra_svg.cpp
+++ b/libkra/kra_svg.cpp
@@ -1,0 +1,11 @@
+// SVG layer support using lunasvg
+// This file is kept for potential future wrapper functions
+// Currently, lunasvg is used directly in kra_layer.cpp
+
+#include "kra_svg.h"
+
+namespace libkra {
+
+// Placeholder - lunasvg is currently used directly in kra_layer.cpp
+
+} // namespace libkra

--- a/libkra/kra_svg.h
+++ b/libkra/kra_svg.h
@@ -1,0 +1,14 @@
+#ifndef KRA_SVG_H
+#define KRA_SVG_H
+
+// SVG support using lunasvg
+// Currently lunasvg is used directly in kra_layer.cpp
+// This header is kept for potential future wrapper functions
+
+namespace libkra {
+
+// Placeholder for future SVG utility functions
+
+} // namespace libkra
+
+#endif // KRA_SVG_H

--- a/libkra/kra_utility.cpp
+++ b/libkra/kra_utility.cpp
@@ -126,4 +126,14 @@ namespace kra
             return false;
         }
     }
+    const char * layer_type_to_string(LayerType type)
+    {
+        switch (type)
+        {
+          case PAINT_LAYER: return "paint";
+          case GROUP_LAYER: return "group";
+          case VECTOR_LAYER: return "vector";
+        }
+        return 0;
+    }
 };

--- a/libkra/kra_utility.cpp
+++ b/libkra/kra_utility.cpp
@@ -100,4 +100,30 @@ namespace kra
                 return "not supported";
         }
     }
+
+    // ---------------------------------------------------------------------------------------------------------------------
+    // Try to match the input string with one of the constants of the LayerType-enum
+    // ---------------------------------------------------------------------------------------------------------------------
+    bool layer_type_from_string(const std::string &node_type, LayerType *out)
+    {
+        if (node_type.compare("paintlayer") == 0)
+        {
+            *out = PAINT_LAYER;
+            return true;
+        }
+        else if (node_type.compare("grouplayer") == 0)
+        {
+            *out = GROUP_LAYER;
+            return true;
+        }
+        else if (node_type.compare("shapelayer") == 0)
+        {
+            *out = VECTOR_LAYER;
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
 };

--- a/libkra/kra_utility.h
+++ b/libkra/kra_utility.h
@@ -21,7 +21,8 @@ namespace kra
     enum LayerType
     {
         PAINT_LAYER,
-        GROUP_LAYER
+        GROUP_LAYER,
+        VECTOR_LAYER
     };
 
     enum ColorSpace
@@ -49,6 +50,8 @@ namespace kra
     ColorSpace get_color_space(const std::string &p_color_space_name);
 
     const std::string get_color_space_name(ColorSpace p_color_space);
+
+    bool layer_type_from_string(const std::string &node_type, LayerType *out);
 };
 
 #endif // KRA_UTILITY_H

--- a/libkra/kra_utility.h
+++ b/libkra/kra_utility.h
@@ -52,6 +52,7 @@ namespace kra
     const std::string get_color_space_name(ColorSpace p_color_space);
 
     bool layer_type_from_string(const std::string &node_type, LayerType *out);
+    const char * layer_type_to_string(LayerType type);
 };
 
 #endif // KRA_UTILITY_H

--- a/libkra_cl/libkra_cl.cpp
+++ b/libkra_cl/libkra_cl.cpp
@@ -116,10 +116,36 @@ void save_layer_to_image(const std::unique_ptr<kra::ExportedLayer> &layer)
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
+// Compose all layers into a single image buffer and save to PNG
+// ---------------------------------------------------------------------------------------------------------------------
+void compose_and_save_document(const std::unique_ptr<kra::Document> &document, const std::string &output_filename)
+{
+	unsigned int width = document->width;
+	unsigned int height = document->height;
+
+	// Allocate RGBA buffer initialized to transparent
+	std::vector<uint8_t> composed_buffer(width * height * 4, 0);
+
+	// Compose each layer onto the buffer (from bottom to top)
+	// Note: layers are stored in reverse order (top layer first), so iterate backwards
+	for (auto it = document->layers.rbegin(); it != document->layers.rend(); ++it)
+	{
+		const auto &layer = *it;
+		std::fprintf(stderr, "Composing layer: %s (type %d)\n", layer->name.c_str(), layer->type);
+		layer->compose(width, height, document->x_res, composed_buffer.data());
+	}
+
+	// Save the composed result
+	std::fprintf(stderr, "Writing composed image to %s\n", output_filename.c_str());
+	write_data_to_png(output_filename.c_str(), width, height, composed_buffer.data());
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
 // Process each layer and, depending on the type, either call the saving method or recursively call this method again.
 // ---------------------------------------------------------------------------------------------------------------------
 void process_layer(const std::unique_ptr<kra::Document> &document, const std::unique_ptr<kra::ExportedLayer> &layer)
 {
+        std::fprintf(stderr, "processing layer %s: type %d\n", layer->name.c_str(), layer->type);
 	switch (layer->type)
 	{
 	case kra::PAINT_LAYER:
@@ -135,6 +161,9 @@ void process_layer(const std::unique_ptr<kra::Document> &document, const std::un
 			process_layer(document, child);
 		}
 		break;
+        default:
+                std::fprintf(stderr, "unhandled layer type %d\n", layer->type);
+                break;
 	}
 }
 


### PR DESCRIPTION
* Integrates the lunasvg library to enable rendering of vector (shapelayer)
  layers with proper DPI scaling, implements a layer composition system with
   alpha blending, and adds support for Krita's default pixel optimization
  for solid-color layers.

